### PR TITLE
Add optional instructions for supporting other browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ so that I know how many customers will arrive at the restaurant on a given day.
 >
 > `<input type="time" />` will store the time in `HH:MM:SS` format. This is a format that works well with the PostgreSQL `time` data type.
 >
+> **Optional** If you want to add support to other browsers such as Safari or IE, you can use the pattern and placeholder attributes along with the date and time inputs in your form. For the date input you can use `<input type="date" placeholder="YYYY-MM-DD" pattern="\d{4}-\d{2}-\d{2}"/>`, and for the time input you can use `<input type="time"               placeholder="HH:MM" pattern="[0-9]{2}:[0-9]{2}"/>`. You can read more about handling browser support [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#handling_browser_support).
+>
 > You can assume that all dates and times will be in your local time zone.
 
 ### US-02 Create reservation on a future, working date

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ so that I know how many customers will arrive at the restaurant on a given day.
 >
 > `<input type="time" />` will store the time in `HH:MM:SS` format. This is a format that works well with the PostgreSQL `time` data type.
 >
-> **Optional** If you want to add support to other browsers such as Safari or IE, you can use the pattern and placeholder attributes along with the date and time inputs in your form. For the date input you can use `<input type="date" placeholder="YYYY-MM-DD" pattern="\d{4}-\d{2}-\d{2}"/>`, and for the time input you can use `<input type="time"               placeholder="HH:MM" pattern="[0-9]{2}:[0-9]{2}"/>`. You can read more about handling browser support [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#handling_browser_support).
+> **Optional** If you want to add support to other browsers such as Safari or IE, you can use the pattern and placeholder attributes along with the date and time inputs in your form. For the date input you can use `<input type="date" placeholder="YYYY-MM-DD" pattern="\d{4}-\d{2}-\d{2}"/>`, and for the time input you can use `<input type="time" placeholder="HH:MM" pattern="[0-9]{2}:[0-9]{2}"/>`. You can read more about handling browser support [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#handling_browser_support).
 >
 > You can assume that all dates and times will be in your local time zone.
 


### PR DESCRIPTION
In the “Cross-browser test your client and fix any bugs” section in Tips, it says:

`It's quite possible that you have only used Google Chrome while developing your client for this application so far. That's fine, but your end users (especially hiring managers!) may use another major browser.

With this in mind, be sure to test your application in several browsers and devices. At a minimum, test it in Safari, Chrome, Firefox, and Microsoft Edge. `

But in the starter project repo it implies that the student should only use Google Chrome:

`The users have confirmed that they will be using Chrome to access the site. This means you can use <input type="date" /> and <input type="time" />, which are supported by Chrome but may not work in other browsers.`

Change as proposed in the solution repo:
https://github.com/Thinkful-Ed/starter-restaurant-reservation-solution/commit/9b6ee29062e9214e7e331732547f3232d7ecb6db

