### PR TITLE
fixed next/previous in date-time

### DIFF
--- a/front-end/src/utils/date-time.js
+++ b/front-end/src/utils/date-time.js
@@ -58,8 +58,9 @@ export function today() {
  */
 export function previous(currentDate) {
   const array = currentDate.split("-");
-  array[1] -= 1;
-  const date = new Date(array[0], array[1], array[2]);
+  let [ year, month, day ] = array;
+  month -= 1;
+  const date = new Date(year, month, day);
   date.setMonth(date.getMonth());
   date.setDate(date.getDate() - 1);
   return asDateString(date);
@@ -74,8 +75,9 @@ export function previous(currentDate) {
  */
 export function next(currentDate) {
   const array = currentDate.split("-");
-  array[1] -= 1;
-  const date = new Date(array[0], array[1], array[2]);
+  let [ year, month, day ] = array;
+  month -= 1;
+  const date = new Date(year, month, day);
   date.setMonth(date.getMonth());
   date.setDate(date.getDate() + 1);
   return asDateString(date);

--- a/front-end/src/utils/date-time.js
+++ b/front-end/src/utils/date-time.js
@@ -57,8 +57,7 @@ export function today() {
  *  the date one day prior to currentDate, formatted as YYYY-MM-DD
  */
 export function previous(currentDate) {
-  const array = currentDate.split("-");
-  let [ year, month, day ] = array;
+  let [ year, month, day ] = currentDate.split("-");
   month -= 1;
   const date = new Date(year, month, day);
   date.setMonth(date.getMonth());
@@ -74,8 +73,7 @@ export function previous(currentDate) {
  *  the date one day after currentDate, formatted as YYYY-MM-DD
  */
 export function next(currentDate) {
-  const array = currentDate.split("-");
-  let [ year, month, day ] = array;
+  let [ year, month, day ] = currentDate.split("-");
   month -= 1;
   const date = new Date(year, month, day);
   date.setMonth(date.getMonth());

--- a/front-end/src/utils/date-time.js
+++ b/front-end/src/utils/date-time.js
@@ -57,8 +57,10 @@ export function today() {
  *  the date one day prior to currentDate, formatted as YYYY-MM-DD
  */
 export function previous(currentDate) {
-  const date = new Date(...currentDate.split("-"));
-  date.setMonth(date.getMonth() - 1);
+  const array = currentDate.split("-");
+  array[1] -= 1;
+  const date = new Date(array[0], array[1], array[2]);
+  date.setMonth(date.getMonth());
   date.setDate(date.getDate() - 1);
   return asDateString(date);
 }
@@ -71,8 +73,10 @@ export function previous(currentDate) {
  *  the date one day after currentDate, formatted as YYYY-MM-DD
  */
 export function next(currentDate) {
-  const date = new Date(...currentDate.split("-"));
-  date.setMonth(date.getMonth() - 1);
+  const array = currentDate.split("-");
+  array[1] -= 1;
+  const date = new Date(array[0], array[1], array[2]);
+  date.setMonth(date.getMonth());
   date.setDate(date.getDate() + 1);
   return asDateString(date);
 }


### PR DESCRIPTION
The issue occurred during the changing of months.

In my particular case, the date went from 03/31/2021 immediately to 04/02/2021 after calling the `next` function once.

While calling the `previous` function from 04/02/2021, it would get stuck at 03/31/2021 and go no further.

Hope it helps!