### PR TITLE
fix: increase timeout for puppeteer expect methods

### DIFF
--- a/front-end/e2e/us-01-create-and-list-reservation.test.js
+++ b/front-end/e2e/us-01-create-and-list-reservation.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -15,6 +16,7 @@ describe("US-01 - Create and list reservations - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
     browser = await puppeteer.launch();
   });
 

--- a/front-end/e2e/us-02-create-reservations-future-date.test.js
+++ b/front-end/e2e/us-02-create-reservations-future-date.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -15,6 +16,7 @@ describe("US-02 - Create reservation on a future, working date - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
   });
 
   beforeEach(async () => {

--- a/front-end/e2e/us-03-create-reservations-eligible-timeframe.test.js
+++ b/front-end/e2e/us-03-create-reservations-eligible-timeframe.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -15,6 +16,7 @@ describe("US-03 - Create reservation on a future, working date - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
   });
 
   beforeEach(async () => {

--- a/front-end/e2e/us-04-seat-reservation.test.js
+++ b/front-end/e2e/us-04-seat-reservation.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -18,6 +19,7 @@ describe("US-04 - Seat reservation - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
     browser = await puppeteer.launch();
   });
 

--- a/front-end/e2e/us-05-finish-occupied-table.test.js
+++ b/front-end/e2e/us-05-finish-occupied-table.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -18,6 +19,7 @@ describe("US-05 - Finish an occupied table - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
     browser = await puppeteer.launch();
   });
 

--- a/front-end/e2e/us-06-reservation-status.test.js
+++ b/front-end/e2e/us-06-reservation-status.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -18,6 +19,7 @@ describe("US-06 - Reservation status - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
     browser = await puppeteer.launch();
   });
 

--- a/front-end/e2e/us-07-search-reservations.test.js
+++ b/front-end/e2e/us-07-search-reservations.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -15,6 +16,7 @@ describe("US-07 - Search reservations - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
   });
 
   beforeEach(async () => {

--- a/front-end/e2e/us-08-change-existing-reservation.test.js
+++ b/front-end/e2e/us-08-change-existing-reservation.test.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { setDefaultOptions } = require('expect-puppeteer');
 const fs = require("fs");
 const fsPromises = fs.promises;
 
@@ -20,6 +21,7 @@ describe("US-08 - Change an existing reservation - E2E", () => {
 
   beforeAll(async () => {
     await fsPromises.mkdir("./.screenshots", { recursive: true });
+    setDefaultOptions({ timeout: 1000 });
     browser = await puppeteer.launch();
   });
 


### PR DESCRIPTION
See tfeng-519. Some tests fail sometimes because the default 500ms timeout for puppeteer expect methods is not enough. 