### PR TITLE
Enable color output highlighting for jest

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -38,7 +38,7 @@
     "test:7": "run-p -l -r test:start:* \"test:e2e:run -- us-07\"",
     "test:8": "run-p -l -r test:start:* \"test:e2e:run -- us-08\"",
     "test:e2e": "run-p -l -r test:start:* test:e2e:run",
-    "test:e2e:run": "wait-on http://localhost:5000/reservations?date=2020-01-01 && jest --detectOpenHandles --forceExit --config ./e2e/jest.config.js",
+    "test:e2e:run": "wait-on http://localhost:5000/reservations?date=2020-01-01 && jest --colors --detectOpenHandles --forceExit --config ./e2e/jest.config.js",
     "test:start:backend": "npm run test:start --prefix ./../back-end",
     "test:start:frontend": "npx cross-env BROWSER=none NODE_ENV=test react-scripts start",
     "test:unit": "react-scripts test"


### PR DESCRIPTION
This [option](https://jestjs.io/docs/cli#--colors)  makes the test output prettier and much easier to parse:

Before:
<img width="690" alt="Screen Shot 2022-03-17 at 3 50 49 PM" src="https://user-images.githubusercontent.com/1432129/158900560-97a725d7-f487-4722-a74a-bd405fe76b22.png">

After:
<img width="680" alt="Screen Shot 2022-03-17 at 3 51 13 PM" src="https://user-images.githubusercontent.com/1432129/158900607-052c8aee-5504-4c01-99cb-0d44ac8c4d6a.png">


